### PR TITLE
refactor: simplify useGetModifiers by removing selection states

### DIFF
--- a/.changeset/plenty-pants-explain.md
+++ b/.changeset/plenty-pants-explain.md
@@ -1,0 +1,14 @@
+---
+'@codefast-ui/number-input': patch
+'@codefast-ui/day-picker': patch
+'@codefast/config-tailwind': patch
+'@codefast-ui/input': patch
+'@codefast/eslint-config': patch
+'@codefast/config-typescript': patch
+'@codefast/hooks': patch
+'@codefast-ui/checkbox-group': patch
+'@codefast/third-parties': patch
+'@codefast/ui': patch
+---
+
+refactor: simplify useGetModifiers by removing selection states

--- a/packages/primitive/day-picker/src/lib/hooks/use-get-modifiers.test.ts
+++ b/packages/primitive/day-picker/src/lib/hooks/use-get-modifiers.test.ts
@@ -1,0 +1,80 @@
+import { CalendarDay, DayFlag, defaultDateLib, useGetModifiers } from '@/lib';
+
+const dateLib = defaultDateLib;
+
+const month1 = new Date(2022, 10, 1);
+const month2 = new Date(2022, 11, 1);
+
+const date1 = new Date(2022, 10, 10);
+const date2 = new Date(2022, 10, 11);
+const date3 = new Date(2022, 10, 12);
+const date4 = new Date(2022, 10, 13);
+const date5 = new Date(2022, 10, 14);
+const date6 = new Date(2022, 10, 30);
+
+const day1 = new CalendarDay(date1, month1);
+const day2 = new CalendarDay(date2, month1);
+const day3 = new CalendarDay(date3, month1);
+const day4 = new CalendarDay(date4, month1);
+const day5 = new CalendarDay(date5, month1);
+const day6 = new CalendarDay(date6, month2);
+
+const days: CalendarDay[] = [day1, day2, day3, day4, day5, day6];
+
+const props = {
+  disabled: [date1],
+  hidden: [date2],
+  modifiers: {
+    custom: [date3],
+    selected: [date5],
+  },
+  selected: date6,
+  showOutsideDays: true,
+  today: date4,
+  timeZone: 'UTC',
+};
+
+describe('useGetModifiers', () => {
+  const getModifiers = useGetModifiers(days, props, dateLib);
+
+  test('return the modifiers for a given day', () => {
+    const modifiers = getModifiers(day1);
+
+    expect(modifiers[DayFlag.focused]).toBe(false);
+    expect(modifiers[DayFlag.disabled]).toBe(true);
+    expect(modifiers[DayFlag.hidden]).toBe(false);
+    expect(modifiers[DayFlag.outside]).toBe(false);
+    expect(modifiers[DayFlag.today]).toBe(false);
+    expect(modifiers.custom).toBe(false);
+  });
+
+  test('return the custom modifiers for a given day', () => {
+    const modifiers = getModifiers(day3);
+
+    expect(modifiers.custom).toBe(true);
+  });
+
+  test('return the custom `selected` modifier for a given day', () => {
+    const modifiers = getModifiers(day5);
+
+    expect(modifiers.selected).toBe(true);
+  });
+
+  test('return the today modifier for a given day', () => {
+    const modifiers = getModifiers(day4);
+
+    expect(modifiers[DayFlag.today]).toBe(true);
+  });
+
+  test('return the hidden modifier for a given day', () => {
+    const modifiers = getModifiers(day2);
+
+    expect(modifiers[DayFlag.hidden]).toBe(true);
+  });
+
+  test('return the outside modifier for a given day', () => {
+    const modifiers = getModifiers(day6);
+
+    expect(modifiers[DayFlag.outside]).toBe(true);
+  });
+});

--- a/packages/primitive/day-picker/src/lib/hooks/use-get-modifiers.ts
+++ b/packages/primitive/day-picker/src/lib/hooks/use-get-modifiers.ts
@@ -1,14 +1,18 @@
 import { TZDate } from '@date-fns/tz';
 
 import { type CalendarDay, type DateLib } from '@/lib/classes';
-import { DayFlag, SelectionState } from '@/lib/constants/ui';
+import { DayFlag } from '@/lib/constants/ui';
 import { type DayPickerProps, type Modifiers } from '@/lib/types';
 import { dateMatchModifiers } from '@/lib/utils/date-match-modifiers';
 
 /**
  * Return a function to get the modifiers for a given day.
  */
-export function useGetModifiers(days: CalendarDay[], props: DayPickerProps, dateLib: DateLib) {
+export function useGetModifiers(
+  days: CalendarDay[],
+  props: DayPickerProps,
+  dateLib: DateLib,
+): (day: CalendarDay) => Modifiers {
   const { disabled, hidden, modifiers, showOutsideDays, today } = props;
 
   const { isSameDay, isSameMonth } = dateLib;
@@ -22,13 +26,6 @@ export function useGetModifiers(days: CalendarDay[], props: DayPickerProps, date
   };
 
   const customModifiersMap: Record<string, CalendarDay[]> = {};
-
-  const selectionModifiersMap: Record<SelectionState, CalendarDay[]> = {
-    [SelectionState.range_end]: [],
-    [SelectionState.range_middle]: [],
-    [SelectionState.range_start]: [],
-    [SelectionState.selected]: [],
-  };
 
   for (const day of days) {
     const { date, displayMonth } = day;
@@ -76,7 +73,7 @@ export function useGetModifiers(days: CalendarDay[], props: DayPickerProps, date
     }
   }
 
-  return (day: CalendarDay) => {
+  return (day: CalendarDay): Modifiers => {
     // Initialize all the modifiers to false
     const dayFlags: Record<DayFlag, boolean> = {
       [DayFlag.focused]: false,
@@ -84,12 +81,6 @@ export function useGetModifiers(days: CalendarDay[], props: DayPickerProps, date
       [DayFlag.hidden]: false,
       [DayFlag.outside]: false,
       [DayFlag.today]: false,
-    };
-    const selectionStates: Record<SelectionState, boolean> = {
-      [SelectionState.range_end]: false,
-      [SelectionState.range_middle]: false,
-      [SelectionState.range_start]: false,
-      [SelectionState.selected]: false,
     };
     const customModifiers: Modifiers = {};
 
@@ -100,21 +91,14 @@ export function useGetModifiers(days: CalendarDay[], props: DayPickerProps, date
       dayFlags[name as DayFlag] = daysForFlag.some((d) => d === day);
     }
 
-    for (const name in selectionModifiersMap) {
-      const daysForState = selectionModifiersMap[name as SelectionState];
-
-      selectionStates[name as SelectionState] = daysForState.some((d) => d === day);
-    }
-
     for (const name in customModifiersMap) {
       customModifiers[name] = Boolean(customModifiersMap[name].some((d) => d === day));
     }
 
     return {
-      ...selectionStates,
       ...dayFlags,
       // custom modifiers should override all the previous ones
       ...customModifiers,
-    } as Modifiers;
+    };
   };
 }


### PR DESCRIPTION
Removed selection state modifiers from useGetModifiers for simplification. Updated the function to only handle day flags and custom modifiers. Added tests to ensure the correct behavior of the simplified function.