### PR TITLE
fix: remove redundant test cases and clarify prop documentation

### DIFF
--- a/.changeset/nervous-bats-wink.md
+++ b/.changeset/nervous-bats-wink.md
@@ -1,0 +1,14 @@
+---
+'@codefast-ui/number-input': patch
+'@codefast-ui/day-picker': patch
+'@codefast/config-tailwind': patch
+'@codefast-ui/input': patch
+'@codefast/eslint-config': patch
+'@codefast/config-typescript': patch
+'@codefast/hooks': patch
+'@codefast-ui/checkbox-group': patch
+'@codefast/third-parties': patch
+'@codefast/ui': patch
+---
+
+fix: remove redundant test cases and clarify prop documentation

--- a/packages/primitive/day-picker/src/lib/helpers/get-nav-month.test.ts
+++ b/packages/primitive/day-picker/src/lib/helpers/get-nav-month.test.ts
@@ -20,12 +20,6 @@ describe('when "startMonth" is passed in', () => {
   test('"startMonth" should be the start of that month', () => {
     expect(navStartMonth).toEqual(new Date(2021, 4, 1));
   });
-
-  describe('when "fromYear" is passed in', () => {
-    test('"startMonth" should be the start of that month', () => {
-      expect(navStartMonth).toEqual(new Date(2021, 4, 1));
-    });
-  });
 });
 
 describe('when "endMonth" is passed in', () => {
@@ -38,12 +32,6 @@ describe('when "endMonth" is passed in', () => {
 
   test('"endMonth" should be the end of that month', () => {
     expect(navEndMonth).toEqual(new Date(2021, 4, 31));
-  });
-
-  describe('when "fromYear" is passed in', () => {
-    test('"endMonth" should be the end of that month', () => {
-      expect(navEndMonth).toEqual(new Date(2021, 4, 31));
-    });
   });
 });
 

--- a/packages/primitive/day-picker/src/lib/types/props.ts
+++ b/packages/primitive/day-picker/src/lib/types/props.ts
@@ -60,7 +60,7 @@ export interface BaseProps {
    * - `year`: display only the dropdown for the years
    *
    * **Note:** showing the dropdown will set the start/end months
-   * {@link fromYear} to 100 years ago, and {@link toYear} to the current year.
+   * {@link startMonth} to 100 years ago, and {@link endMonth} to the current year.
    */
   captionLayout?: 'label' | 'dropdown' | 'dropdown-months' | 'dropdown-years';
 


### PR DESCRIPTION
Removed duplicate test cases for "fromYear" that were already covered under main month tests. Updated prop documentation to correctly reference start and end months instead of fromYear and toYear.