### PR TITLE
fix: use default locale when custom locale is absent

### DIFF
--- a/.changeset/smart-dingos-shave.md
+++ b/.changeset/smart-dingos-shave.md
@@ -1,0 +1,14 @@
+---
+'@codefast-ui/number-input': patch
+'@codefast-ui/day-picker': patch
+'@codefast/config-tailwind': patch
+'@codefast-ui/input': patch
+'@codefast/eslint-config': patch
+'@codefast/config-typescript': patch
+'@codefast/hooks': patch
+'@codefast-ui/checkbox-group': patch
+'@codefast/third-parties': patch
+'@codefast/ui': patch
+---
+
+fix: use default locale when custom locale is absent

--- a/packages/primitive/day-picker/src/lib/classes/date-lib.ts
+++ b/packages/primitive/day-picker/src/lib/classes/date-lib.ts
@@ -406,6 +406,7 @@ export class DateLib {
     return this.overrides?.startOfYear ? this.overrides.startOfYear(date) : startOfYear(date);
   };
 }
+
 /**
  * The default locale (English).
  */

--- a/packages/primitive/day-picker/src/lib/formatters/format-month-dropdown.test.ts
+++ b/packages/primitive/day-picker/src/lib/formatters/format-month-dropdown.test.ts
@@ -1,11 +1,12 @@
 import { es } from 'date-fns/locale/es';
 
+import { defaultLocale } from '@/lib/classes/date-lib';
 import { formatMonthDropdown } from '@/lib/formatters/format-month-dropdown';
 
 const date = new Date(2022, 10, 21);
 
 test('should return the formatted month dropdown label', () => {
-  expect(formatMonthDropdown(date.getMonth())).toEqual('November');
+  expect(formatMonthDropdown(date.getMonth(), defaultLocale)).toEqual('November');
 });
 
 describe('when a locale is passed in', () => {

--- a/packages/primitive/day-picker/src/lib/formatters/format-month-dropdown.ts
+++ b/packages/primitive/day-picker/src/lib/formatters/format-month-dropdown.ts
@@ -1,4 +1,4 @@
-import { type DateFnsMonth, defaultLocale } from '@/lib/classes/date-lib';
+import { type DateFnsMonth, type Locale } from '@/lib/classes/date-lib';
 
 /**
  * Format the month number for the dropdown option label.
@@ -14,7 +14,7 @@ export function formatMonthDropdown(
   /**
    * The locale to use for formatting.
    */
-  locale = defaultLocale,
+  locale: Locale,
 ): string {
   return locale.localize.month(monthNumber as DateFnsMonth);
 }

--- a/packages/primitive/day-picker/src/lib/helpers/get-month-options.ts
+++ b/packages/primitive/day-picker/src/lib/helpers/get-month-options.ts
@@ -1,5 +1,5 @@
 import { type DropdownOption } from '@/components/ui/dropdown';
-import { type DateLib } from '@/lib/classes/date-lib';
+import { type DateLib, defaultLocale } from '@/lib/classes/date-lib';
 import { type Formatters } from '@/lib/types';
 
 /**
@@ -30,7 +30,7 @@ export function getMonthOptions(
   const sortedMonths = months.sort((a, b) => a - b);
 
   return sortedMonths.map((value) => {
-    const label = formatters.formatMonthDropdown(value, dateLib.options.locale);
+    const label = formatters.formatMonthDropdown(value, dateLib.options.locale ?? defaultLocale);
     const month = new dateLib.Date(year, value);
     const disabled = month < startOfMonth(navStart) || month > startOfMonth(navEnd) || false;
 


### PR DESCRIPTION
Updated month dropdown formatting to use a default locale if a custom one is not provided. Adjusted related imports and tests to accommodate this change.