### PR TITLE
feat(day-picker): ensure fixed weeks display 42 days consistently

### DIFF
--- a/.changeset/orange-rats-crash.md
+++ b/.changeset/orange-rats-crash.md
@@ -1,0 +1,14 @@
+---
+'@codefast-ui/number-input': patch
+'@codefast-ui/day-picker': patch
+'@codefast/config-tailwind': patch
+'@codefast-ui/input': patch
+'@codefast/eslint-config': patch
+'@codefast/config-typescript': patch
+'@codefast/hooks': patch
+'@codefast-ui/checkbox-group': patch
+'@codefast/third-parties': patch
+'@codefast/ui': patch
+---
+
+feat(day-picker): ensure fixed weeks display 42 days consistently

--- a/packages/primitive/day-picker/examples/fixed-weeks.test.tsx
+++ b/packages/primitive/day-picker/examples/fixed-weeks.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+
+import { FixedWeeks } from './fixed-weeks';
+
+describe('fixed-weeks component', () => {
+  render(<FixedWeeks />);
+
+  test('should render 42*12 days', () => {
+    expect(screen.getAllByRole('cell')).toHaveLength(42 * 12);
+  });
+});

--- a/packages/primitive/day-picker/examples/fixed-weeks.tsx
+++ b/packages/primitive/day-picker/examples/fixed-weeks.tsx
@@ -1,0 +1,7 @@
+import { type JSX } from 'react';
+
+import { DayPicker } from '@/components';
+
+export function FixedWeeks(): JSX.Element {
+  return <DayPicker fixedWeeks showOutsideDays showWeekNumber defaultMonth={new Date(2026, 1)} numberOfMonths={12} />;
+}

--- a/packages/primitive/day-picker/src/lib/helpers/get-dates.test.ts
+++ b/packages/primitive/day-picker/src/lib/helpers/get-dates.test.ts
@@ -86,6 +86,25 @@ describe('getDates Helper Function', () => {
         expect(dates[dates.length - 1]).toEqual(new Date(2023, 5, 4)); // Last day
       });
     });
+
+    describe('when the month has 4 weeks', () => {
+      const month = new Date(2026, 1); // February 2026
+
+      describe('when not using fixed weeks', () => {
+        it('should return 28 dates', () => {
+          const dates = getDates([month], undefined, { fixedWeeks: false }, defaultDateLib);
+
+          expect(dates).toHaveLength(28);
+        });
+      });
+      describe('when using fixed weeks', () => {
+        it('should return 42 dates', () => {
+          const dates = getDates([month], undefined, { fixedWeeks: true }, defaultDateLib);
+
+          expect(dates).toHaveLength(42);
+        });
+      });
+    });
   });
 
   describe('when the first month and the last month are different', () => {

--- a/packages/primitive/day-picker/src/lib/helpers/get-dates.ts
+++ b/packages/primitive/day-picker/src/lib/helpers/get-dates.ts
@@ -4,7 +4,7 @@ import { type DayPickerProps } from '@/lib/types';
 /**
  * The number of days in a month when having 6 weeks.
  */
-const NrOfDaysWithFixedWeeks = 42;
+export const NrOfDaysWithFixedWeeks = 42;
 
 /**
  * Return all the dates to display in the calendar.
@@ -55,7 +55,9 @@ export function getDates(
   const extraDates = NrOfDaysWithFixedWeeks * nOfMonths;
 
   if (fixedWeeks && dates.length < extraDates) {
-    for (let i = 0; i < 7; i++) {
+    const daysToAdd = extraDates - dates.length;
+
+    for (let i = 0; i < daysToAdd; i++) {
       const date = addDays(dates[dates.length - 1], 1);
 
       dates.push(date);

--- a/packages/primitive/day-picker/src/lib/helpers/get-months.ts
+++ b/packages/primitive/day-picker/src/lib/helpers/get-months.ts
@@ -1,5 +1,6 @@
 import { CalendarDay, CalendarMonth, CalendarWeek } from '@/lib/classes';
 import { type DateLib } from '@/lib/classes/date-lib';
+import { NrOfDaysWithFixedWeeks } from '@/lib/helpers/get-dates';
 import { type DayPickerProps } from '@/lib/types';
 
 /**
@@ -35,9 +36,11 @@ export function getMonths(
       return date >= firstDateOfFirstWeek && date <= lastDateOfLastWeek;
     });
 
-    if (props.fixedWeeks && monthDates.length < 42) {
+    if (props.fixedWeeks && monthDates.length < NrOfDaysWithFixedWeeks) {
       const extraDates = dates.filter((date) => {
-        return date > lastDateOfLastWeek && date <= addDays(lastDateOfLastWeek, 7);
+        const daysToAdd = NrOfDaysWithFixedWeeks - monthDates.length;
+
+        return date > lastDateOfLastWeek && date <= addDays(lastDateOfLastWeek, daysToAdd);
       });
 
       monthDates.push(...extraDates);


### PR DESCRIPTION
Refactored 'get-months.ts' to use a constant for the number of days with fixed weeks. Added new tests and components to validate that fixed weeks display exactly 42 days.