### PR TITLE
fix: use full-depth clone in GitHub Actions

### DIFF
--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1 # Shallow clone for faster checkout
+          fetch-depth: 0
 
       - name: Check for Changes
         uses: dorny/paths-filter@v3


### PR DESCRIPTION
Changed fetch-depth from 1 to 0 in version-and-release.yml. This ensures that the full repository history is cloned, which might be necessary for certain Git actions.