### PR TITLE
refactor(workflows): separate PR validation and versioning

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
       - name: 'Auto-assign issue'
-        uses: pozil/auto-assign-issue@v1
+        uses: pozil/auto-assign-issue@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           assignees: thevuong

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,13 +1,6 @@
-name: Create Version PR
+name: PR Validation
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - '**.md'
-      - '.gitignore'
-      - '.editorconfig'
-      - 'docs/**'
   pull_request:
     branches: [main]
     paths-ignore:
@@ -31,7 +24,6 @@ jobs:
     outputs:
       ui_changed: ${{ steps.filter.outputs.ui }}
       test_required: ${{ steps.filter.outputs.test }}
-      has_changeset: ${{ steps.filter.outputs.changeset }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -57,16 +49,11 @@ jobs:
               - 'jest.config.{js,ts}'
               - 'vitest.config.{js,ts}'
               - '**/tests/**'
-            changeset:
-              - '.changeset/**/*.md'
-              - '.changeset/config.json'
 
       - name: Log Filter Outputs
         run: |
           echo "UI Changed: ${{ steps.filter.outputs.ui }}"
           echo "Test Required: ${{ steps.filter.outputs.test }}"
-          echo "Changeset Exists: ${{ steps.filter.outputs.changeset }}"
-          echo "Message: ${{ github.event.head_commit.message }}"
 
   lint:
     name: Lint
@@ -86,9 +73,7 @@ jobs:
   test:
     name: Test
     needs: [setup, lint]
-    if: |
-      needs.setup.outputs.test_required == 'true' ||
-      contains(github.event.head_commit.message, '[force-test]')
+    if: needs.setup.outputs.test_required == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -104,10 +89,7 @@ jobs:
   chromatic:
     name: Visual Testing
     needs: [setup, lint]
-    if: |
-      needs.setup.outputs.ui_changed == 'true' &&
-      (github.event_name == 'pull_request' || github.ref == 'refs/heads/main') &&
-      !contains(github.event.head_commit.message, '[skip-visual]')
+    if: needs.setup.outputs.ui_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -126,34 +108,3 @@ jobs:
           workingDir: apps/storybook-docs
           onlyChanged: true
           zip: true
-
-  version:
-    name: Create Version PR
-    needs: [setup, lint, test]
-    if: |
-      github.ref == 'refs/heads/main' &&
-      github.event_name == 'push' &&
-      needs.setup.outputs.has_changeset == 'true' &&
-      !contains(github.event.head_commit.message, '[skip-release]') &&
-      (needs.setup.outputs.test_required == 'false' || success())
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Environment
-        uses: ./.github/actions/setup-env
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Create Version PR
-        id: changesets
-        uses: changesets/action@v1
-        with:
-          version: pnpm changeset:version
-          title: 'chore(release): version packages'
-          commit: 'chore(release): version packages'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -24,6 +24,7 @@ jobs:
     outputs:
       ui_changed: ${{ steps.filter.outputs.ui }}
       test_required: ${{ steps.filter.outputs.test }}
+      lint_required: ${{ steps.filter.outputs.lint }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -41,7 +42,7 @@ jobs:
               - '**/*.stories.{js,jsx,ts,tsx}'
               - '**/styles/**'
             test:
-              - 'packages/**/src/**/*.{js,jsx,ts,tsx}'
+              - 'packages/**/src/**/*.{js,jsx,ts,tsx,css,scss}'
               - 'packages/**/__tests__/**'
               - 'packages/**/test/**'
               - '**/*.test.{js,jsx,ts,tsx}'
@@ -49,15 +50,19 @@ jobs:
               - 'jest.config.{js,ts}'
               - 'vitest.config.{js,ts}'
               - '**/tests/**'
+            lint:
+              - 'packages/**/src/**/*.{js,jsx,ts,tsx,css,scss}'
 
       - name: Log Filter Outputs
         run: |
           echo "UI Changed: ${{ steps.filter.outputs.ui }}"
           echo "Test Required: ${{ steps.filter.outputs.test }}"
+          echo "Lint Required: ${{ steps.filter.outputs.lint }}"
 
   lint:
     name: Lint
     needs: setup
+    if: needs.setup.outputs.lint_required == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,68 @@
+name: PR Validation
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - '.gitignore'
+      - '.editorconfig'
+      - 'docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: 20
+  SKIP_INSTALL_SIMPLE_GIT_HOOKS: true
+
+jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    outputs:
+      has_changeset: ${{ steps.filter.outputs.changeset }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Check for Changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            changeset:
+              - '.changeset/**/*.md'
+              - '.changeset/config.json'
+
+      - name: Log Filter Outputs
+        run: |
+          echo "Changeset Exists: ${{ steps.filter.outputs.changeset }}"
+
+  version:
+    name: Create Version PR
+    needs: [setup]
+    if: needs.setup.outputs.has_changeset == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Create Version PR
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: pnpm changeset:version
+          title: 'chore(release): version packages'
+          commit: 'chore(release): version packages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Renamed version-pr.yml to pr-validation.yml and scoped it to PR checks only. Extracted versioning logic into a new versioning.yml workflow, triggering on main branch pushes with changesets.