### PR TITLE
fix(workflow): correct filters in versioning workflow

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           filters: |
             changeset:
-              - '.changeset/**/*.md'
+              - added|modified: '.changeset/**/*.md'
               - '.changeset/config.json'
 
       - name: Log Filter Outputs


### PR DESCRIPTION
The filter was incorrectly matching changesets. Updated to specify 'added|modified' for changes in '.changeset/**/*.md' to ensure proper versioning behavior. This will help in accurately detecting and logging changes.