### PR TITLE
feat(ci): add build packages step to CI workflows

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -39,7 +39,3 @@ runs:
     - name: Install Dependencies
       shell: bash
       run: pnpm install --frozen-lockfile
-
-    - name: Build Packages
-      shell: bash
-      run: pnpm build:packages

--- a/.github/workflows/pr-validation-and-versioning.yml
+++ b/.github/workflows/pr-validation-and-versioning.yml
@@ -86,6 +86,10 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Build Packages
+        shell: bash
+        run: pnpm build:packages
+
       - name: Run Lint
         run: pnpm lint
 
@@ -103,6 +107,10 @@ jobs:
         uses: ./.github/actions/setup-env
         with:
           node-version: ${{ env.NODE_VERSION }}
+
+      - name: Build Packages
+        shell: bash
+        run: pnpm build:packages
 
       - name: Run Tests
         run: pnpm test
@@ -123,6 +131,10 @@ jobs:
         uses: ./.github/actions/setup-env
         with:
           node-version: ${{ env.NODE_VERSION }}
+
+      - name: Build Packages
+        shell: bash
+        run: pnpm build:packages
 
       - name: Run Chromatic
         uses: chromaui/action@latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,10 +21,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Setup Environment
         uses: ./.github/actions/setup-env
         with:
           node-version: ${{ env.NODE_VERSION }}
+
       - name: Publish to NPM
         uses: changesets/action@v1
         with:


### PR DESCRIPTION
Added a 'Build Packages' step to the PR validation, versioning, and publish workflows. This ensures packages are built before linting, testing, and publishing. Removed duplicate build step from setup-env action.