### PR TITLE
feat(sidebars): add Sidebar 13 example

### DIFF
--- a/apps/docs/app/blocks/sidebar-12/_lib/mocks/data.ts
+++ b/apps/docs/app/blocks/sidebar-12/_lib/mocks/data.ts
@@ -2,7 +2,7 @@ export const data = {
   user: {
     name: 'shadcn',
     email: 'm@example.com',
-    avatar: '/avatars/shadcn.jpg',
+    avatar: '/avatars/01.png',
   },
   calendars: [
     {

--- a/apps/docs/app/blocks/sidebar-13/_components/sidebar-13.tsx
+++ b/apps/docs/app/blocks/sidebar-13/_components/sidebar-13.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  Button,
+  cn,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+} from '@codefast/ui';
+import { type ComponentProps, type JSX, useState } from 'react';
+
+import { data } from '@/app/blocks/sidebar-13/_lib/mocks/data';
+
+type Sidebar13Props = ComponentProps<'div'>;
+
+export function Sidebar13({ className, ...props }: Sidebar13Props): JSX.Element {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div className={cn('', className)} {...props}>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger asChild>
+          <Button size="sm">Open Dialog</Button>
+        </DialogTrigger>
+        <DialogContent className="grid overflow-hidden p-0 md:max-h-[500px] md:max-w-[700px] lg:max-w-[800px]">
+          <DialogTitle className="sr-only">Settings</DialogTitle>
+          <DialogDescription className="sr-only">Customize your settings here.</DialogDescription>
+          <SidebarProvider className="items-start">
+            <Sidebar className="hidden md:flex" collapsible="none">
+              <SidebarContent>
+                <SidebarGroup>
+                  <SidebarGroupContent>
+                    <SidebarMenu>
+                      {data.nav.map((item) => (
+                        <SidebarMenuItem key={item.name}>
+                          <SidebarMenuButton asChild isActive={item.name === 'Messages & media'}>
+                            <a href="#">
+                              <item.icon />
+                              <span>{item.name}</span>
+                            </a>
+                          </SidebarMenuButton>
+                        </SidebarMenuItem>
+                      ))}
+                    </SidebarMenu>
+                  </SidebarGroupContent>
+                </SidebarGroup>
+              </SidebarContent>
+            </Sidebar>
+            <main className="flex h-[480px] flex-1 flex-col overflow-hidden">
+              <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12">
+                <div className="flex items-center gap-2 px-4">
+                  <Breadcrumb>
+                    <BreadcrumbList>
+                      <BreadcrumbItem className="hidden md:block">
+                        <BreadcrumbLink href="#">Settings</BreadcrumbLink>
+                      </BreadcrumbItem>
+                      <BreadcrumbSeparator className="hidden md:block" />
+                      <BreadcrumbItem>
+                        <BreadcrumbPage>Messages & media</BreadcrumbPage>
+                      </BreadcrumbItem>
+                    </BreadcrumbList>
+                  </Breadcrumb>
+                </div>
+              </header>
+              <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-4 pt-0">
+                {Array.from({ length: 10 }).map((_, index) => (
+                  // eslint-disable-next-line react/no-array-index-key -- key is safe
+                  <div key={index} className="bg-muted/50 aspect-video max-w-3xl rounded-xl" />
+                ))}
+              </div>
+            </main>
+          </SidebarProvider>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/docs/app/blocks/sidebar-13/_lib/mocks/data.ts
+++ b/apps/docs/app/blocks/sidebar-13/_lib/mocks/data.ts
@@ -1,0 +1,31 @@
+import {
+  BellIcon,
+  CheckIcon,
+  GlobeIcon,
+  HomeIcon,
+  KeyboardIcon,
+  LinkIcon,
+  LockIcon,
+  MenuIcon,
+  MessageCircleIcon,
+  PaintbrushIcon,
+  SettingsIcon,
+  VideoIcon,
+} from 'lucide-react';
+
+export const data = {
+  nav: [
+    { name: 'Notifications', icon: BellIcon },
+    { name: 'Navigation', icon: MenuIcon },
+    { name: 'Home', icon: HomeIcon },
+    { name: 'Appearance', icon: PaintbrushIcon },
+    { name: 'Messages & media', icon: MessageCircleIcon },
+    { name: 'Language & region', icon: GlobeIcon },
+    { name: 'Accessibility', icon: KeyboardIcon },
+    { name: 'Mark as read', icon: CheckIcon },
+    { name: 'Audio & video', icon: VideoIcon },
+    { name: 'Connected accounts', icon: LinkIcon },
+    { name: 'Privacy & visibility', icon: LockIcon },
+    { name: 'Advanced', icon: SettingsIcon },
+  ],
+};

--- a/apps/docs/app/blocks/sidebar-13/page.tsx
+++ b/apps/docs/app/blocks/sidebar-13/page.tsx
@@ -1,0 +1,16 @@
+import { type Metadata } from 'next';
+import { type JSX } from 'react';
+
+import { Sidebar13 } from '@/app/blocks/sidebar-13/_components/sidebar-13';
+
+export const metadata: Metadata = {
+  title: 'Sidebar 13',
+};
+
+export default function Sidebar13Page(): JSX.Element {
+  return (
+    <main className="flex h-svh items-center justify-center">
+      <Sidebar13 />
+    </main>
+  );
+}

--- a/apps/docs/app/examples/sidebars/page.tsx
+++ b/apps/docs/app/examples/sidebars/page.tsx
@@ -23,6 +23,7 @@ export default function SidebarPage(): JSX.Element {
         <SidebarLink href="/blocks/sidebar-10" title="Sidebar 10" />
         <SidebarLink href="/blocks/sidebar-11" title="Sidebar 11" />
         <SidebarLink href="/blocks/sidebar-12" title="Sidebar 12" />
+        <SidebarLink href="/blocks/sidebar-13" title="Sidebar 13" />
       </div>
     </main>
   );


### PR DESCRIPTION
Introduced a new "Sidebar 13" example with corresponding components and mock data. Additionally, updated the sidebar navigation to include the new example link.