### PR TITLE
chore: simplify Vercel deploy workflow triggers

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -1,15 +1,6 @@
 name: Deploy to Vercel
 
 on:
-  push:
-    branches: [main, develop, "feature/**", "fix/**", "release/**"]
-    paths:
-      - "apps/**"
-      - "packages/**"
-      - "pnpm-lock.yaml"
-      - ".github/workflows/vercel-deploy.yml"
-      - "!**/*.{test,spec,e2e}.{ts,tsx,js,jsx}"
-      - "!**/{__tests__,tests,e2e,__mocks__}/**"
   pull_request:
     branches: [main, develop]
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
Adjust the workflow triggers by removing specific branch and file path conditions for push events. This streamlines the configuration, ensuring pull requests remain the primary trigger for deployments. The change also removes unnecessary complexity in monitoring changes.