### PR TITLE
chore: sort catalog alphabetically, bump deps, and refactor web app

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -5,7 +5,7 @@ author: "codefastlabs"
 inputs:
   node-version:
     description: "Node.js version to use (align with root package.json engines)"
-    default: "24"
+    default: "lts/*"
     required: false
 
   package-manager-version:

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -3,9 +3,9 @@ description: "Sets up Node.js, pnpm, and project dependencies with caching for e
 author: "codefastlabs"
 
 inputs:
-  node-version:
-    description: "Node.js version to use (align with root package.json engines)"
-    default: "lts/*"
+  node-version-file:
+    description: "File containing the Node.js version to use (e.g. .node-version)"
+    default: ".node-version"
     required: false
 
   package-manager-version:
@@ -57,7 +57,7 @@ runs:
       id: node-setup
       uses: actions/setup-node@v6
       with:
-        node-version: ${{ inputs.node-version }}
+        node-version-file: ${{ inputs.node-version-file }}
         cache: "pnpm"
 
     - name: "Install Project Dependencies (pnpm)"

--- a/packages/benchmark-viewer/src/app/components/chart.tsx
+++ b/packages/benchmark-viewer/src/app/components/chart.tsx
@@ -232,7 +232,7 @@ export function ChartPanel({
         label: `${lib.displayName} hz/op (median)`,
         data: hz,
         borderColor: paletteEntry.border,
-        backgroundColor: paletteEntry.band.replace(/[\d.]+\)$/, "0.08)"),
+        backgroundColor: `${paletteEntry.band.slice(0, paletteEntry.band.lastIndexOf(",") + 1)} 0.08)`,
         spanGaps: false,
         yAxisID: "y",
         tension: 0.12,

--- a/packages/theme/src/script/theme-script.tsx
+++ b/packages/theme/src/script/theme-script.tsx
@@ -4,9 +4,18 @@ import { MEDIA } from "#/constants";
 import { colorSchemes } from "#/types";
 import type { ColorScheme } from "#/types";
 
+/* JSON.stringify does not escape </script>, so we replace the three characters that
+ * can form a closing tag: < > /. Unicode escapes are valid JS and safe in HTML. */
+function toScriptSafe(value: unknown): string {
+  return JSON.stringify(value)
+    .replaceAll("<", "\\u003C")
+    .replaceAll(">", "\\u003E")
+    .replaceAll("/", "\\u002F");
+}
+
 /* Derived once from schema + constants — inline script uses these to stay in sync */
-const COLOR_SCHEME_REMOVE_ARGS = colorSchemes.map((s) => JSON.stringify(s)).join(",");
-const COLOR_SCHEME_VALID_CHECK = colorSchemes.map((s) => `s===${JSON.stringify(s)}`).join("||");
+const COLOR_SCHEME_REMOVE_ARGS = colorSchemes.map((s) => toScriptSafe(s)).join(",");
+const COLOR_SCHEME_VALID_CHECK = colorSchemes.map((s) => `s===${toScriptSafe(s)}`).join("||");
 
 /* -----------------------------------------------------------------------------
  * Props
@@ -74,12 +83,11 @@ export function AppearanceScript({
   storageKey,
   colorScheme,
 }: AppearanceScriptProps): JSX.Element {
-  // S2: Use JSON.stringify for safe JS string serialisation — guards against injection if
-  // TypeScript's type-narrowing is bypassed (e.g. a raw string from an unvalidated source).
+  // S2: toScriptSafe = JSON.stringify + escape <>/  so </script> cannot break out of the tag.
   // F1: When storageKey is provided, the script reads localStorage before first paint so
   // client-only apps (no SSR cookie) get the right color scheme without FOUC.
   // sk=null short-circuits to s=null so color scheme falls back to fbt — backward-compatible.
-  const appearanceScript = `(function(){try{var sk=${JSON.stringify(storageKey ?? null)},fbt=${JSON.stringify(colorScheme)},s=sk&&localStorage.getItem(sk),theme=(${COLOR_SCHEME_VALID_CHECK})?s:fbt,resolvedTheme=theme;"automatic"===theme&&(resolvedTheme=window.matchMedia(${JSON.stringify(MEDIA)}).matches?"dark":"light"),document.documentElement.classList.remove(${COLOR_SCHEME_REMOVE_ARGS}),document.documentElement.classList.add(resolvedTheme),document.documentElement.style.colorScheme=resolvedTheme}catch(e){}})()`;
+  const appearanceScript = `(function(){try{var sk=${toScriptSafe(storageKey ?? null)},fbt=${toScriptSafe(colorScheme)},s=sk&&localStorage.getItem(sk),theme=(${COLOR_SCHEME_VALID_CHECK})?s:fbt,resolvedTheme=theme;"automatic"===theme&&(resolvedTheme=window.matchMedia(${toScriptSafe(MEDIA)}).matches?"dark":"light"),document.documentElement.classList.remove(${COLOR_SCHEME_REMOVE_ARGS}),document.documentElement.classList.add(resolvedTheme),document.documentElement.style.colorScheme=resolvedTheme}catch(e){}})()`;
   const nonceProps = nonce === undefined ? {} : { nonce };
 
   return (


### PR DESCRIPTION
## Summary

- **Catalog**: sort `pnpm-workspace.yaml` alphabetically and bump dependencies
- **Web app**: refactor imports to absolute `#/` aliases, convert `export default` to named exports, rename `Footer.tsx` → `footer.tsx`, add `@unpic/react` and self-hosted Inter font via `@fontsource-variable/inter`
- **CI**: read Node.js version from `.node-version` file (currently `26.1.0`) instead of `lts/*` to ensure consistent runtime across local dev and CI
- **engines.node**: bump to `>=24.0.0` across all packages
- **Security**: fix CodeQL alert [#73](https://github.com/codefastlabs/codefast/security/code-scanning/73) (ReDoS in `benchmark-viewer`) and [#85](https://github.com/codefastlabs/codefast/security/code-scanning/85) (improper code sanitization in `theme`)

## Test plan

- [ ] Vercel preview deployment builds successfully
- [ ] CI passes (Workspace Package Verification)
- [ ] CodeQL alerts #73 and #85 resolved after merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)