### PR TITLE
feat(web): expand command palette shortcuts and a11y hints

### DIFF
--- a/apps/web/src/components/layout/command-palette-keyboard.test.ts
+++ b/apps/web/src/components/layout/command-palette-keyboard.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getCommandPaletteAriaKeyshortcuts,
+  getCommandPaletteKeyboardAction,
+  isEditableTarget,
+} from "#/components/layout/command-palette-keyboard";
+
+function createKeyboardEvent(init: KeyboardEventInit & { target?: EventTarget | null }): KeyboardEvent {
+  const { target = document.body, ...eventInit } = init;
+  const event = new KeyboardEvent("keydown", eventInit);
+  Object.defineProperty(event, "target", { value: target });
+  return event;
+}
+
+describe("getCommandPaletteKeyboardAction", () => {
+  it("opens on / when the palette is closed and focus is not editable", () => {
+    const event = createKeyboardEvent({ key: "/" });
+
+    expect(getCommandPaletteKeyboardAction(event, false)).toBe("open");
+  });
+
+  it("ignores / when the palette is already open", () => {
+    const event = createKeyboardEvent({ key: "/" });
+
+    expect(getCommandPaletteKeyboardAction(event, true)).toBeNull();
+  });
+
+  it("ignores / while typing in an input", () => {
+    const input = document.createElement("input");
+    const event = createKeyboardEvent({ key: "/", target: input });
+
+    expect(getCommandPaletteKeyboardAction(event, false)).toBeNull();
+  });
+
+  it("toggles on modifier+/ and modifier+k", () => {
+    expect(getCommandPaletteKeyboardAction(createKeyboardEvent({ key: "/", metaKey: true }), false)).toBe("toggle");
+    expect(getCommandPaletteKeyboardAction(createKeyboardEvent({ key: "k", ctrlKey: true }), true)).toBe("toggle");
+  });
+});
+
+describe("isEditableTarget", () => {
+  it("detects editable elements", () => {
+    expect(isEditableTarget(document.createElement("input"))).toBe(true);
+    expect(isEditableTarget(document.createElement("div"))).toBe(false);
+  });
+});
+
+describe("getCommandPaletteAriaKeyshortcuts", () => {
+  it("lists only platform-relevant modifier shortcuts", () => {
+    expect(getCommandPaletteAriaKeyshortcuts(true)).toBe("/ Meta+Slash Meta+K");
+    expect(getCommandPaletteAriaKeyshortcuts(false)).toBe("/ Control+Slash Control+K");
+  });
+});

--- a/apps/web/src/components/layout/command-palette-keyboard.ts
+++ b/apps/web/src/components/layout/command-palette-keyboard.ts
@@ -1,0 +1,53 @@
+const EDITABLE_SELECTOR = 'input, textarea, select, [contenteditable=""], [contenteditable="true"]' as const;
+
+export type CommandPaletteKeyboardAction = "open" | "toggle";
+
+function hasPrimaryModifier(event: KeyboardEvent): boolean {
+  return event.metaKey || event.ctrlKey;
+}
+
+/** Skip `/` when focus is inside an editable field or the palette is already open. */
+export function isEditableTarget(target: EventTarget | null): boolean {
+  return target instanceof Element && target.closest(EDITABLE_SELECTOR) !== null;
+}
+
+/**
+ * Maps a keydown to a palette action:
+ * - `/` opens when closed (not while typing in an input)
+ * - ⌘/ / Ctrl+/ and ⌘K / Ctrl+K toggle from anywhere
+ */
+export function getCommandPaletteKeyboardAction(
+  event: KeyboardEvent,
+  open: boolean,
+): CommandPaletteKeyboardAction | null {
+  if (hasPrimaryModifier(event) && !event.shiftKey && !event.altKey) {
+    if (event.key === "/") {
+      return "toggle";
+    }
+
+    if (event.key.toLowerCase() === "k") {
+      return "toggle";
+    }
+
+    return null;
+  }
+
+  if (event.key !== "/" || event.shiftKey || event.altKey || hasPrimaryModifier(event)) {
+    return null;
+  }
+
+  if (open || isEditableTarget(event.target)) {
+    return null;
+  }
+
+  return "open";
+}
+
+export function getIsMacPlatform(): boolean {
+  return /Mac|iPhone|iPod|iPad/i.test(navigator.platform);
+}
+
+/** ARIA tokens only — slash is universal; modifier shortcuts match the user's OS. */
+export function getCommandPaletteAriaKeyshortcuts(isMac: boolean): string {
+  return isMac ? "/ Meta+Slash Meta+K" : "/ Control+Slash Control+K";
+}

--- a/apps/web/src/components/layout/command-palette.tsx
+++ b/apps/web/src/components/layout/command-palette.tsx
@@ -11,8 +11,13 @@ import {
 import { Kbd } from "@codefast/ui/kbd";
 import { useNavigate } from "@tanstack/react-router";
 import { SearchIcon } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useEffectEvent, useState, useSyncExternalStore } from "react";
 
+import {
+  getCommandPaletteAriaKeyshortcuts,
+  getCommandPaletteKeyboardAction,
+  getIsMacPlatform,
+} from "#/components/layout/command-palette-keyboard";
 import { COMPONENTS } from "#/registry/components";
 
 const PAGES = [
@@ -22,27 +27,42 @@ const PAGES = [
 ] as const;
 
 /**
- * Global ⌘K / Ctrl+K command palette. Renders its own trigger (a search field
- * on desktop, an icon button on mobile) plus the dialog, and reads the
- * lightweight component registry so it never pulls the heavy demo bundle.
+ * Global command palette: `/`, ⌘/ / Ctrl+/, and ⌘K / Ctrl+K. Renders its own
+ * trigger (a search field on desktop, an icon button on mobile) plus the dialog,
+ * and reads the lightweight component registry so it never pulls the heavy demo bundle.
  */
 export function CommandPalette() {
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
+  const isMac = useSyncExternalStore(
+    () => () => {},
+    getIsMacPlatform,
+    () => false,
+  );
+  const ariaKeyshortcuts = getCommandPaletteAriaKeyshortcuts(isMac);
 
-  // ⌘K (mac) / Ctrl+K (others) toggles the palette from anywhere.
-  useEffect(() => {
-    function onKeyDown(event: KeyboardEvent): void {
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
-        event.preventDefault();
-        setOpen((value) => !value);
-      }
+  const onGlobalKeyDown = useEffectEvent((event: KeyboardEvent): void => {
+    const action = getCommandPaletteKeyboardAction(event, open);
+
+    if (!action) {
+      return;
     }
 
-    document.addEventListener("keydown", onKeyDown);
+    event.preventDefault();
+
+    if (action === "toggle") {
+      setOpen((value) => !value);
+      return;
+    }
+
+    setOpen(true);
+  });
+
+  useEffect(() => {
+    document.addEventListener("keydown", onGlobalKeyDown);
 
     return () => {
-      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("keydown", onGlobalKeyDown);
     };
   }, []);
 
@@ -75,12 +95,13 @@ export function CommandPalette() {
         onClick={() => {
           setOpen(true);
         }}
+        aria-keyshortcuts={ariaKeyshortcuts}
         aria-label="Search components"
         variant="secondary"
       >
         <SearchIcon className="size-4 shrink-0" />
         <span className="hidden flex-1 text-left text-sm lg:inline">Search components…</span>
-        <Kbd className="hidden lg:inline-flex">⌘K</Kbd>
+        <Kbd className="hidden lg:inline-flex">/</Kbd>
       </Button>
 
       <CommandDialog open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
Add /, modifier+/, and modifier+K bindings with OS-specific aria-keyshortcuts, a stable useEffectEvent listener, and keyboard helper tests.