### PR TITLE
feat(ui): render indeterminate state across checkbox family

### DIFF
--- a/.changeset/checkbox-indeterminate-state.md
+++ b/.changeset/checkbox-indeterminate-state.md
@@ -1,0 +1,5 @@
+---
+"@codefast/ui": minor
+---
+
+feat(checkbox): render the indeterminate state across the checkbox family — fill the box and swap to a minus icon when `data-state="indeterminate"`, with a matching `data-indeterminate` variant

--- a/apps/web/src/registry/checkbox/doc.ts
+++ b/apps/web/src/registry/checkbox/doc.ts
@@ -1,6 +1,7 @@
 import { CheckboxBasic } from "#/registry/checkbox/basic.example";
 import { CheckboxDescription } from "#/registry/checkbox/description.example";
 import { CheckboxDisabled } from "#/registry/checkbox/disabled.example";
+import { CheckboxIndeterminate } from "#/registry/checkbox/indeterminate.example";
 import { CheckboxInvalid } from "#/registry/checkbox/invalid.example";
 import { CheckboxRtl } from "#/registry/checkbox/rtl.example";
 import { CheckboxInTable } from "#/registry/checkbox/table.example";
@@ -30,6 +31,14 @@ export const checkboxDoc: ComponentDoc = {
         "Use the disabled prop to prevent interaction and add the data-disabled attribute to the <Field> component for disabled styles.",
       Demo: CheckboxDisabled,
       source: docSource("checkbox", "disabled"),
+    },
+    {
+      id: "checkbox-indeterminate",
+      title: "Indeterminate",
+      description:
+        'Pass checked="indeterminate" to a parent that controls a list when only some children are selected.',
+      Demo: CheckboxIndeterminate,
+      source: docSource("checkbox", "indeterminate"),
     },
     {
       id: "checkbox-invalid",

--- a/apps/web/src/registry/checkbox/indeterminate.example.tsx
+++ b/apps/web/src/registry/checkbox/indeterminate.example.tsx
@@ -1,0 +1,63 @@
+import { Checkbox } from "@codefast/ui/checkbox";
+import { Field, FieldGroup, FieldLabel } from "@codefast/ui/field";
+import { useState } from "react";
+
+const items = [
+  { id: "recents", label: "Recents" },
+  { id: "home", label: "Home" },
+  { id: "applications", label: "Applications" },
+];
+
+export function CheckboxIndeterminate() {
+  const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set(["home"]));
+
+  const allChecked = checkedIds.size === items.length;
+  const someChecked = checkedIds.size > 0 && !allChecked;
+  const parentState = someChecked ? "indeterminate" : allChecked;
+
+  const handleParentChange = (checked: boolean | "indeterminate") => {
+    setCheckedIds(checked === true ? new Set(items.map((item) => item.id)) : new Set());
+  };
+
+  const handleChildChange = (id: string, checked: boolean | "indeterminate") => {
+    setCheckedIds((previous) => {
+      const next = new Set(previous);
+
+      if (checked === true) {
+        next.add(id);
+      } else {
+        next.delete(id);
+      }
+
+      return next;
+    });
+  };
+
+  return (
+    <FieldGroup className="mx-auto w-56">
+      <Field orientation="horizontal">
+        <Checkbox
+          aria-label="Select all"
+          id="parent-checkbox"
+          checked={parentState}
+          onCheckedChange={handleParentChange}
+        />
+        <FieldLabel htmlFor="parent-checkbox">Select all</FieldLabel>
+      </Field>
+      <FieldGroup className="ms-6 gap-3">
+        {items.map((item) => (
+          <Field key={item.id} orientation="horizontal">
+            <Checkbox
+              id={`child-${item.id}`}
+              checked={checkedIds.has(item.id)}
+              onCheckedChange={(checked) => {
+                handleChildChange(item.id, checked);
+              }}
+            />
+            <FieldLabel htmlFor={`child-${item.id}`}>{item.label}</FieldLabel>
+          </Field>
+        ))}
+      </FieldGroup>
+    </FieldGroup>
+  );
+}

--- a/apps/web/src/registry/checkbox/table.example.tsx
+++ b/apps/web/src/registry/checkbox/table.example.tsx
@@ -32,10 +32,12 @@ const tableData = [
 export function CheckboxInTable() {
   const [selectedRows, setSelectedRows] = React.useState<Set<string>>(new Set(["1"]));
 
-  const selectAll = selectedRows.size === tableData.length;
+  const allSelected = selectedRows.size === tableData.length;
+  const someSelected = selectedRows.size > 0 && !allSelected;
+  const selectAllState = someSelected ? "indeterminate" : allSelected;
 
-  const handleSelectAll = (checked: boolean) => {
-    if (checked) {
+  const handleSelectAll = (checked: boolean | "indeterminate") => {
+    if (checked === true) {
       setSelectedRows(new Set(tableData.map((row) => row.id)));
     } else {
       setSelectedRows(new Set());
@@ -58,9 +60,10 @@ export function CheckboxInTable() {
         <TableRow>
           <TableHead className="w-8">
             <Checkbox
+              aria-label="Select all rows"
               id="select-all-checkbox"
               name="select-all-checkbox"
-              checked={selectAll}
+              checked={selectAllState}
               onCheckedChange={handleSelectAll}
             />
           </TableHead>

--- a/packages/ui/src/components/checkbox-cards.tsx
+++ b/packages/ui/src/components/checkbox-cards.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon } from "lucide-react";
+import { CheckIcon, MinusIcon } from "lucide-react";
 import type { ComponentProps, JSX } from "react";
 
 import { Label } from "#/components/label";
@@ -39,24 +39,25 @@ function CheckboxCardsItem({ checkboxClassName, children, className, ...props }:
   return (
     <Label
       className={cn(
-        "flex items-start gap-3 rounded-md border border-input p-3 transition has-focus-visible:border-ring has-disabled:opacity-50 has-data-checked:border-primary/30 has-data-checked:bg-primary/5",
+        "flex items-start gap-3 rounded-md border border-input p-3 transition has-focus-visible:border-ring has-disabled:opacity-50 has-data-checked:border-primary/30 has-data-checked:bg-primary/5 has-data-indeterminate:border-primary/30 has-data-indeterminate:bg-primary/5",
         className,
       )}
       data-slot="checkbox-card"
     >
       <CheckboxGroupPrimitive.Item
         className={cn(
-          "peer relative flex size-4 shrink-0 items-center justify-center rounded-sm border border-input shadow-xs transition-shadow duration-control ease-snappy outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+          "peer relative flex size-4 shrink-0 items-center justify-center rounded-sm border border-input shadow-xs transition-shadow duration-control ease-snappy outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary data-indeterminate:border-primary data-indeterminate:bg-primary data-indeterminate:text-primary-foreground dark:data-indeterminate:bg-primary",
           checkboxClassName,
         )}
         data-slot="checkbox-card-item"
         {...props}
       >
         <CheckboxGroupPrimitive.CheckboxGroupIndicator
-          className="grid animate-in place-content-center text-current duration-control-indicator ease-spring zoom-in-50 [&>svg]:size-3.5"
+          className="group/checkbox-card-indicator grid animate-in place-content-center text-current duration-control-indicator ease-spring zoom-in-50 [&>svg]:size-3.5"
           data-slot="checkbox-card-indicator"
         >
-          <CheckIcon />
+          <CheckIcon className="group-data-indeterminate/checkbox-card-indicator:hidden" />
+          <MinusIcon className="hidden group-data-indeterminate/checkbox-card-indicator:block" />
         </CheckboxGroupPrimitive.CheckboxGroupIndicator>
       </CheckboxGroupPrimitive.Item>
       {children}

--- a/packages/ui/src/components/checkbox-group.tsx
+++ b/packages/ui/src/components/checkbox-group.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon } from "lucide-react";
+import { CheckIcon, MinusIcon } from "lucide-react";
 import type { ComponentProps, JSX } from "react";
 
 import { cn } from "#/lib/utils";
@@ -36,17 +36,18 @@ function CheckboxGroupItem({ className, ...props }: CheckboxGroupItemProps): JSX
   return (
     <CheckboxGroupPrimitive.Item
       className={cn(
-        "peer relative flex size-4 shrink-0 items-center justify-center rounded-sm border border-input shadow-xs transition-shadow duration-control ease-snappy outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+        "peer relative flex size-4 shrink-0 items-center justify-center rounded-sm border border-input shadow-xs transition-shadow duration-control ease-snappy outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary data-indeterminate:border-primary data-indeterminate:bg-primary data-indeterminate:text-primary-foreground dark:data-indeterminate:bg-primary",
         className,
       )}
       data-slot="checkbox-group-item"
       {...props}
     >
       <CheckboxGroupPrimitive.CheckboxGroupIndicator
-        className="grid animate-in place-content-center text-current duration-control-indicator ease-spring zoom-in-50 [&>svg]:size-3.5"
+        className="group/checkbox-group-indicator grid animate-in place-content-center text-current duration-control-indicator ease-spring zoom-in-50 [&>svg]:size-3.5"
         data-slot="checkbox-group-indicator"
       >
-        <CheckIcon />
+        <CheckIcon className="group-data-indeterminate/checkbox-group-indicator:hidden" />
+        <MinusIcon className="hidden group-data-indeterminate/checkbox-group-indicator:block" />
       </CheckboxGroupPrimitive.CheckboxGroupIndicator>
     </CheckboxGroupPrimitive.Item>
   );

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon } from "lucide-react";
+import { CheckIcon, MinusIcon } from "lucide-react";
 import { Checkbox as CheckboxPrimitive } from "radix-ui";
 import type { ComponentProps, JSX } from "react";
 
@@ -20,17 +20,18 @@ function Checkbox({ className, ...props }: CheckboxProps): JSX.Element {
   return (
     <CheckboxPrimitive.Root
       className={cn(
-        "peer relative flex size-4 shrink-0 items-center justify-center rounded-sm border border-input shadow-xs transition-shadow duration-control ease-snappy outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+        "peer relative flex size-4 shrink-0 items-center justify-center rounded-sm border border-input shadow-xs transition-shadow duration-control ease-snappy outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary data-indeterminate:border-primary data-indeterminate:bg-primary data-indeterminate:text-primary-foreground dark:data-indeterminate:bg-primary",
         className,
       )}
       data-slot="checkbox"
       {...props}
     >
       <CheckboxPrimitive.Indicator
-        className="grid animate-in place-content-center text-current duration-control-indicator ease-spring zoom-in-50 [&>svg]:size-3.5"
+        className="group/checkbox-indicator grid animate-in place-content-center text-current duration-control-indicator ease-spring zoom-in-50 [&>svg]:size-3.5"
         data-slot="checkbox-indicator"
       >
-        <CheckIcon />
+        <CheckIcon className="group-data-indeterminate/checkbox-indicator:hidden" />
+        <MinusIcon className="hidden group-data-indeterminate/checkbox-indicator:block" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   );

--- a/packages/ui/src/css/foundation/variants.css
+++ b/packages/ui/src/css/foundation/variants.css
@@ -74,6 +74,13 @@
   }
 }
 
+@custom-variant data-indeterminate {
+  &:where([data-state="indeterminate"]),
+  &:where([data-indeterminate]:not([data-indeterminate="false"])) {
+    @slot;
+  }
+}
+
 /* data-selected only matches explicit true, not bare data-selected. */
 @custom-variant data-selected {
   &:where([data-state="selected"]),


### PR DESCRIPTION
## What

Make the **indeterminate** state actually render across the whole checkbox family (`Checkbox`, `CheckboxGroup`, `CheckboxCards`), and demonstrate it in the web docs.

## Why

Radix sets `data-state="indeterminate"` (`aria-checked="mixed"`) when a checkbox is mixed, but the components only handled `data-checked:` — they always rendered `CheckIcon` and never filled the box. So the *documented* indeterminate state (the docs already mention `aria-checked="mixed"` and "a parent that controls a list") showed a wrong check icon on a blank background. The table's select-all also stayed visually unchecked when only some rows were selected.

## Changes

**`packages/ui`**
- `css/foundation/variants.css` — new `data-indeterminate` custom variant matching `[data-state="indeterminate"]`, consistent with the existing `data-checked` / `data-unchecked` variants.
- `components/checkbox.tsx`, `checkbox-group.tsx`, `checkbox-cards.tsx` — fill the box (primary bg/border/fg) for indeterminate and swap `CheckIcon` → `MinusIcon` via `group-data-indeterminate`.
- `checkbox-cards.tsx` — card label also highlights on `has-data-indeterminate`, mirroring `has-data-checked`.

**`apps/web`**
- `registry/checkbox/table.example.tsx` — select-all now goes `indeterminate` when partially selected (+ `aria-label`).
- `registry/checkbox/indeterminate.example.tsx` — new parent/child "Select all" example.
- `registry/checkbox/doc.ts` — register the new example.

## Reviewer notes

- `CheckboxGroup`/`CheckboxCards` items are **membership-based** (`checked = value.includes(item)`) and the primitive intentionally omits `checked`/`onCheckedChange`, so a group item cannot enter indeterminate through the group API. The styling is added for **family consistency** / forward-safety; indeterminate is genuinely exercised by the standalone `Checkbox` acting as a parent over a list.
- Changeset included: `@codefast/ui` **minor**.

## Verification

- `pnpm run check-types`, oxlint, `pnpm run build:packages` all pass.
- Browser-verified on the running dev server: for `data-state="indeterminate"` the box fills with primary and shows the minus icon (check hidden), `checked` shows the check, `unchecked` shows nothing — confirmed across checkbox, checkbox-group, and checkbox-cards. No console errors.