### PR TITLE
fix(ui): align menubar-label with dropdown/context menu family

### DIFF
--- a/.changeset/menubar-label-align.md
+++ b/.changeset/menubar-label-align.md
@@ -1,0 +1,5 @@
+---
+"@codefast/ui": patch
+---
+
+fix(menubar): align `menubar-label` styling with the dropdown/context menu family — use `text-xs` and `text-muted-foreground` to match `dropdown-menu-label` and `context-menu-label`

--- a/packages/ui/src/components/menubar.tsx
+++ b/packages/ui/src/components/menubar.tsx
@@ -327,7 +327,7 @@ interface MenubarLabelProps extends ComponentProps<typeof MenubarPrimitive.Label
 function MenubarLabel({ className, inset, ...props }: MenubarLabelProps): JSX.Element {
   return (
     <MenubarPrimitive.Label
-      className={cn("px-2 py-1.5 text-sm font-medium data-inset:ps-8", className)}
+      className={cn("px-2 py-1.5 text-xs font-medium text-muted-foreground data-inset:ps-8", className)}
       data-inset={inset}
       data-slot="menubar-label"
       {...props}


### PR DESCRIPTION
## What

Sync `data-slot="menubar-label"` styling with its sibling labels in the menu family:

```diff
- "px-2 py-1.5 text-sm font-medium data-inset:ps-8"
+ "px-2 py-1.5 text-xs font-medium text-muted-foreground data-inset:ps-8"
```

Now `menubar-label` matches `dropdown-menu-label` and `context-menu-label` exactly.

## Why

The 2026-06-06 "align with cf-menu patterns" refactor batch migrated all three menu labels in the same minute:

| Commit | Component | Result |
| --- | --- | --- |
| `b9c1556b5` | context-menu | `text-xs font-medium text-muted-foreground` ✅ |
| `602482265` | dropdown-menu | `text-xs font-medium text-muted-foreground` ✅ |
| `47560e2bd` | menubar | `text-sm font-medium` ❌ |

menubar (done last) only received 2 of the 4 changes its siblings got — it kept `text-sm` and was missing `text-muted-foreground`. This was an incomplete migration, not an intentional difference (the same commit still applied `font-semibold`→`font-medium` and removed `flex items-center gap-x-2`). This PR finishes that alignment.

`select-label` is intentionally left as-is — Select is a separate family with no inset and its own label convention.

## Notes for reviewers

- Visual impact: menubar labels become slightly smaller (`text-xs`) and muted (`text-muted-foreground`), matching dropdown/context menus.
- Changeset included (`@codefast/ui`: patch).
- `pnpm run check-types` passes across the repo.