### PR TITLE
refactor(web): drop dead `order` field and realign category to A–Z listing

### DIFF
--- a/apps/web/src/components/detail/detail-header.tsx
+++ b/apps/web/src/components/detail/detail-header.tsx
@@ -22,8 +22,8 @@ interface ComponentDetailHeaderProps {
 }
 
 /**
- * The detail-page masthead: category breadcrumb, title and description, source /
- * npm links, and the install + import-path panel.
+ * The detail-page masthead: breadcrumb, title and description, source / npm
+ * links, and the install + import-path panel.
  */
 const STATUS_BADGE: Record<"beta" | "deprecated", { label: string; className: string }> = {
   beta: { label: "Beta", className: "border-amber-500/40 text-amber-600 dark:text-amber-400" },
@@ -46,16 +46,6 @@ export function ComponentDetailHeader({ component }: ComponentDetailHeaderProps)
           <BreadcrumbItem>
             <BreadcrumbLink asChild>
               <Link to="/components">Components</Link>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator>
-            <ChevronRightIcon />
-          </BreadcrumbSeparator>
-          <BreadcrumbItem>
-            <BreadcrumbLink asChild>
-              <Link to="/components" hash={category}>
-                {categoryLabel}
-              </Link>
             </BreadcrumbLink>
           </BreadcrumbItem>
           <BreadcrumbSeparator>

--- a/apps/web/src/components/layout/command-palette.tsx
+++ b/apps/web/src/components/layout/command-palette.tsx
@@ -75,15 +75,15 @@ export function CommandPalette() {
   );
 
   const goToComponent = useCallback(
-    (slug: string, hasDemo: boolean, category: string) => {
+    (slug: string, hasDemo: boolean, name: string) => {
       setOpen(false);
 
       if (hasDemo) {
         // Components with a demo have a dedicated detail page.
         void navigate({ to: "/components/$slug", params: { slug } });
       } else {
-        // Sidebar (no demo) jumps to its section on the overview.
-        void navigate({ to: "/components", hash: category });
+        // Sidebar (no demo) jumps to its A–Z letter band on the overview.
+        void navigate({ to: "/components", hash: `letter-${name.charAt(0).toUpperCase()}` });
       }
     },
     [navigate],
@@ -128,7 +128,7 @@ export function CommandPalette() {
                   key={component.slug}
                   value={`${component.name} ${component.category}`}
                   onSelect={() => {
-                    goToComponent(component.slug, component.hasDemo, component.category);
+                    goToComponent(component.slug, component.hasDemo, component.name);
                   }}
                 >
                   <span className="grow">{component.name}</span>

--- a/apps/web/src/registry/accordion/meta.ts
+++ b/apps/web/src/registry/accordion/meta.ts
@@ -3,7 +3,6 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Accordion",
   category: "layout",
-  order: 20,
   description: "Expandable sections with smooth animation. Supports single or multiple open items.",
   wide: true,
 };

--- a/apps/web/src/registry/alert-dialog/meta.ts
+++ b/apps/web/src/registry/alert-dialog/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Alert Dialog",
   category: "overlay",
-  order: 50,
   description: "Blocking confirmation modal requiring an explicit decision. Backs the browser back button.",
 };

--- a/apps/web/src/registry/alert/meta.ts
+++ b/apps/web/src/registry/alert/meta.ts
@@ -3,7 +3,6 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Alert",
   category: "display",
-  order: 20,
   description: "Contextual banner with icon, title, and body. Supports default and destructive variants.",
   wide: true,
 };

--- a/apps/web/src/registry/aspect-ratio/meta.ts
+++ b/apps/web/src/registry/aspect-ratio/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Aspect Ratio",
   category: "display",
-  order: 60,
   description: "Locks content to a specific width-to-height ratio. Useful for images, videos, and embeds.",
 };

--- a/apps/web/src/registry/avatar/meta.ts
+++ b/apps/web/src/registry/avatar/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Avatar",
   category: "display",
-  order: 30,
   description: "User icon with image support and initials fallback. Compose with AvatarGroup for stacks.",
 };

--- a/apps/web/src/registry/badge/meta.ts
+++ b/apps/web/src/registry/badge/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Badge",
   category: "display",
-  order: 10,
   description: "Compact label for status, category, or count. Four variants cover most use cases.",
 };

--- a/apps/web/src/registry/breadcrumb/meta.ts
+++ b/apps/web/src/registry/breadcrumb/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Breadcrumb",
   category: "navigation",
-  order: 20,
   description: "Hierarchical location trail. Supports custom separators, ellipsis, and asChild links.",
 };

--- a/apps/web/src/registry/button-group/meta.ts
+++ b/apps/web/src/registry/button-group/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Button Group",
   category: "form",
-  order: 20,
   description: "Horizontal or vertical group that visually joins adjacent buttons into a single control.",
 };

--- a/apps/web/src/registry/button/meta.ts
+++ b/apps/web/src/registry/button/meta.ts
@@ -3,7 +3,6 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Button",
   category: "form",
-  order: 10,
   description: "Six variants and four sizes. Supports icons, loading state, and asChild composition.",
   wide: true,
 };

--- a/apps/web/src/registry/calendar/meta.ts
+++ b/apps/web/src/registry/calendar/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Calendar",
   category: "form",
-  order: 220,
   description: "Full calendar built on @daypicker/react. Supports single, multiple, and range selection.",
 };

--- a/apps/web/src/registry/card/meta.ts
+++ b/apps/web/src/registry/card/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Card",
   category: "layout",
-  order: 10,
   description: "Elevated surface for grouping related content. Compose Header, Content, and Footer slots freely.",
 };

--- a/apps/web/src/registry/carousel/meta.ts
+++ b/apps/web/src/registry/carousel/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Carousel",
   category: "display",
-  order: 70,
   description: "Embla-powered slide carousel with prev/next controls. Supports horizontal and vertical axes.",
 };

--- a/apps/web/src/registry/chart/meta.ts
+++ b/apps/web/src/registry/chart/meta.ts
@@ -3,7 +3,6 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Chart",
   category: "display",
-  order: 80,
   description: "Recharts wrapper with consistent theming, tooltip, and legend. Supports all chart types.",
   wide: true,
 };

--- a/apps/web/src/registry/checkbox-cards/meta.ts
+++ b/apps/web/src/registry/checkbox-cards/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Checkbox Cards",
   category: "form",
-  order: 140,
   description: "Card-style multi-select. Each card has a built-in checkbox with highlighted selected state.",
 };

--- a/apps/web/src/registry/checkbox-group/meta.ts
+++ b/apps/web/src/registry/checkbox-group/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Checkbox Group",
   category: "form",
-  order: 130,
   description: "Multi-select group of checkboxes sharing a value array. Supports disabled items.",
 };

--- a/apps/web/src/registry/checkbox/meta.ts
+++ b/apps/web/src/registry/checkbox/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Checkbox",
   category: "form",
-  order: 120,
   description: "Binary control with indeterminate state. Controlled or uncontrolled via onCheckedChange.",
 };

--- a/apps/web/src/registry/collapsible/meta.ts
+++ b/apps/web/src/registry/collapsible/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Collapsible",
   category: "layout",
-  order: 50,
   description: "Togglable content section with animated expand/collapse. Controlled or uncontrolled.",
 };

--- a/apps/web/src/registry/command/meta.ts
+++ b/apps/web/src/registry/command/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Command",
   category: "overlay",
-  order: 60,
   description: "Command palette with fuzzy search, groups, keyboard shortcuts, and empty state.",
 };

--- a/apps/web/src/registry/components.test.ts
+++ b/apps/web/src/registry/components.test.ts
@@ -17,19 +17,15 @@ describe("metadata registry", () => {
     }
   });
 
+  it("sorts components A–Z by name", () => {
+    const names = COMPONENTS.map((component) => component.name);
+    const sorted = [...names].toSorted((a, b) => a.localeCompare(b));
+    expect(names).toEqual(sorted);
+  });
+
   it("assigns every component to a known category", () => {
     for (const { category } of COMPONENTS) {
       expect(CATEGORY_IDS.has(category)).toBe(true);
-    }
-  });
-
-  it("uses a unique order per category so the curated sort is total", () => {
-    const seen = new Map<string, string>();
-
-    for (const { category, order, slug } of COMPONENTS) {
-      const key = `${category}:${order}`;
-      expect(seen.get(key), `${slug} reuses order ${order} in ${category} (taken by ${seen.get(key)})`).toBeUndefined();
-      seen.set(key, slug);
     }
   });
 

--- a/apps/web/src/registry/components.ts
+++ b/apps/web/src/registry/components.ts
@@ -9,10 +9,10 @@
  * so the whole registry bundles into one tiny chunk that any route (home hero,
  * /components showcase, ⌘K palette, detail pages) can import freely.
  *
- * Display order on /components is curated: components sort by category (the
- * `CATEGORIES` order below), then by their `order` field within the category.
- * `order` values are sparse (10, 20, 30, …) so a new component slots between
- * two others without renumbering; ties fall back to the display name.
+ * Display order on /components is alphabetical by name (see `groups.ts`), so the
+ * registry sorts the same way and the detail-page pager walks components A–Z.
+ * `category` no longer drives that order — it survives as a descriptive tag for
+ * the detail-page badge and the ⌘K palette (label + search keyword).
  *
  * TO ADD A COMPONENT: create `registry/<slug>/meta.ts` exporting a single
  * `ComponentMetaInput` — it appears everywhere automatically. Add a
@@ -25,6 +25,7 @@ import { DEMO_BY_SLUG } from "#/registry/demos";
 /* Categories                                                                  */
 /* -------------------------------------------------------------------------- */
 
+/** Descriptive taxonomy tag — surfaced as a badge / palette label, not a sort key. */
 export const CATEGORIES = [
   {
     id: "display",
@@ -72,9 +73,8 @@ export type ComponentStatus = "stable" | "beta" | "deprecated";
 export interface ComponentMetaInput {
   /** Display name, e.g. "Alert Dialog". */
   readonly name: string;
+  /** Descriptive taxonomy tag (badge + palette search) — does not affect ordering. */
   readonly category: CategoryId;
-  /** Curated position within the category on /components — sparse, leave gaps. */
-  readonly order: number;
   readonly description: string;
   /** Render the showcase card across two grid columns. */
   readonly wide?: boolean;
@@ -115,11 +115,7 @@ function slugFromMetaPath(path: string): string {
   return slug;
 }
 
-const CATEGORY_RANK: ReadonlyMap<CategoryId, number> = new Map(
-  CATEGORIES.map((category, index) => [category.id, index]),
-);
-
-/** Every component, in the exact order the /components grid renders. */
+/** Every component, sorted A–Z by name — the order the /components grid renders. */
 export const COMPONENTS: ReadonlyArray<ComponentMeta> = Object.entries(metaModules)
   .map(([path, module]) => {
     const slug = slugFromMetaPath(path);
@@ -130,11 +126,7 @@ export const COMPONENTS: ReadonlyArray<ComponentMeta> = Object.entries(metaModul
 
     return { ...module.meta, slug, hasDemo: DEMO_BY_SLUG.has(slug) };
   })
-  .toSorted((a, b) => {
-    const rank = (CATEGORY_RANK.get(a.category) ?? 0) - (CATEGORY_RANK.get(b.category) ?? 0);
-
-    return rank || a.order - b.order || a.name.localeCompare(b.name);
-  });
+  .toSorted((a, b) => a.name.localeCompare(b.name));
 
 /** O(1) slug lookup — routes resolve params against this instead of scanning. */
 export const COMPONENT_BY_SLUG: ReadonlyMap<string, ComponentMeta> = new Map(

--- a/apps/web/src/registry/context-menu/meta.ts
+++ b/apps/web/src/registry/context-menu/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Context Menu",
   category: "overlay",
-  order: 70,
   description: "Right-click menu with items, checkboxes, radio groups, submenus, and shortcuts.",
 };

--- a/apps/web/src/registry/data-table/meta.ts
+++ b/apps/web/src/registry/data-table/meta.ts
@@ -3,7 +3,6 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Data Table",
   category: "display",
-  order: 120,
   description: "A sortable, filterable, paginated table built with TanStack Table and the Table primitives.",
   wide: true,
   composition: ["@tanstack/react-table", "Table"],

--- a/apps/web/src/registry/date-picker/meta.ts
+++ b/apps/web/src/registry/date-picker/meta.ts
@@ -3,7 +3,6 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Date Picker",
   category: "form",
-  order: 225,
   description: "A date and date-range picker composed from a Popover and the Calendar component.",
   composition: ["Calendar", "Popover"],
 };

--- a/apps/web/src/registry/dialog/meta.ts
+++ b/apps/web/src/registry/dialog/meta.ts
@@ -3,7 +3,6 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Dialog",
   category: "overlay",
-  order: 10,
   description:
     "Modal window with focus trap, backdrop blur, and accessible close. Use AlertDialog for destructive confirms.",
 };

--- a/apps/web/src/registry/drawer/meta.ts
+++ b/apps/web/src/registry/drawer/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Drawer",
   category: "overlay",
-  order: 80,
   description: "Bottom sheet drawer built on Vaul. Supports drag-to-dismiss and scale background.",
 };

--- a/apps/web/src/registry/dropdown-menu/meta.ts
+++ b/apps/web/src/registry/dropdown-menu/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Dropdown Menu",
   category: "overlay",
-  order: 40,
   description: "Contextual action menu with keyboard navigation, shortcuts, checkboxes, and radio groups.",
 };

--- a/apps/web/src/registry/empty/meta.ts
+++ b/apps/web/src/registry/empty/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Empty",
   category: "display",
-  order: 90,
   description: "Empty-state layout with media, title, description, and action slots.",
 };

--- a/apps/web/src/registry/field/meta.ts
+++ b/apps/web/src/registry/field/meta.ts
@@ -3,7 +3,6 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Field",
   category: "form",
-  order: 240,
   description:
     "Layout wrapper that composes label, description, error, and control in vertical or horizontal orientation.",
   wide: true,

--- a/apps/web/src/registry/form/meta.ts
+++ b/apps/web/src/registry/form/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Form",
   category: "form",
-  order: 250,
   description: "React Hook Form integration with accessible label, description, and error message binding.",
 };

--- a/apps/web/src/registry/hover-card/meta.ts
+++ b/apps/web/src/registry/hover-card/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Hover Card",
   category: "overlay",
-  order: 90,
   description: "Rich preview card that appears on hover. Ideal for user profiles and link previews.",
 };

--- a/apps/web/src/registry/input-group/meta.ts
+++ b/apps/web/src/registry/input-group/meta.ts
@@ -3,7 +3,6 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Input Group",
   category: "form",
-  order: 40,
   description: "Composes an input with leading/trailing addons, text labels, and icon buttons.",
   wide: true,
 };

--- a/apps/web/src/registry/input-number/meta.ts
+++ b/apps/web/src/registry/input-number/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Input Number",
   category: "form",
-  order: 50,
   description: "Numeric input with increment/decrement controls, min/max/step, and format options.",
 };

--- a/apps/web/src/registry/input-otp/meta.ts
+++ b/apps/web/src/registry/input-otp/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Input OTP",
   category: "form",
-  order: 60,
   description: "One-time password input with slot groups and separator. Built on input-otp.",
 };

--- a/apps/web/src/registry/input-password/meta.ts
+++ b/apps/web/src/registry/input-password/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Input Password",
   category: "form",
-  order: 70,
   description: "Password field with a show/hide toggle. Extends Input Group with no extra markup.",
 };

--- a/apps/web/src/registry/input-search/meta.ts
+++ b/apps/web/src/registry/input-search/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Input Search",
   category: "form",
-  order: 80,
   description: "Search field with a leading icon and a one-click clear button. Controlled or uncontrolled.",
 };

--- a/apps/web/src/registry/input/meta.ts
+++ b/apps/web/src/registry/input/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Input",
   category: "form",
-  order: 30,
   description: "Text input with focus ring, disabled state, and file input styling.",
 };

--- a/apps/web/src/registry/item/meta.ts
+++ b/apps/web/src/registry/item/meta.ts
@@ -3,7 +3,6 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Item",
   category: "display",
-  order: 100,
   description: "Row layout for lists. Composes media, content, title, description, and action slots.",
   wide: true,
 };

--- a/apps/web/src/registry/kbd/meta.ts
+++ b/apps/web/src/registry/kbd/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Kbd",
   category: "display",
-  order: 50,
   description: "Keyboard shortcut display. Use KbdGroup to compose multi-key combos.",
 };

--- a/apps/web/src/registry/label/meta.ts
+++ b/apps/web/src/registry/label/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Label",
   category: "form",
-  order: 230,
   description: "Accessible form label that forwards htmlFor. Pairs with any form control.",
 };

--- a/apps/web/src/registry/menubar/meta.ts
+++ b/apps/web/src/registry/menubar/meta.ts
@@ -3,7 +3,6 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Menubar",
   category: "navigation",
-  order: 40,
   description: "Horizontal menu bar with dropdowns, checkboxes, radio items, and keyboard navigation.",
   wide: true,
 };

--- a/apps/web/src/registry/native-select/meta.ts
+++ b/apps/web/src/registry/native-select/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Native Select",
   category: "form",
-  order: 110,
   description: "Styled HTML select element with option groups. Zero JS — best for mobile forms.",
 };

--- a/apps/web/src/registry/navigation-menu/meta.ts
+++ b/apps/web/src/registry/navigation-menu/meta.ts
@@ -3,7 +3,6 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Navigation Menu",
   category: "navigation",
-  order: 50,
   description: "Animated mega-menu with animated content panels. Built on Radix NavigationMenu.",
   wide: true,
 };

--- a/apps/web/src/registry/pagination/meta.ts
+++ b/apps/web/src/registry/pagination/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Pagination",
   category: "navigation",
-  order: 30,
   description: "Page navigation with prev/next, ellipsis, and active page. Compose with your router.",
 };

--- a/apps/web/src/registry/popover/meta.ts
+++ b/apps/web/src/registry/popover/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Popover",
   category: "overlay",
-  order: 30,
   description: "Non-modal floating panel anchored to a trigger. Use for settings panels and pickers.",
 };

--- a/apps/web/src/registry/progress-circle/meta.ts
+++ b/apps/web/src/registry/progress-circle/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Progress Circle",
   category: "feedback",
-  order: 20,
   description: "Circular progress indicator with optional value label and animation. Multiple sizes.",
 };

--- a/apps/web/src/registry/progress/meta.ts
+++ b/apps/web/src/registry/progress/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Progress",
   category: "feedback",
-  order: 10,
   description: "Determinate progress bar. Pass value 0–100. Colour via className on the indicator slot.",
 };

--- a/apps/web/src/registry/radio-cards/meta.ts
+++ b/apps/web/src/registry/radio-cards/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Radio Cards",
   category: "form",
-  order: 170,
   description: "Card-style single-select. Each card highlights when selected, ideal for plan pickers.",
 };

--- a/apps/web/src/registry/radio-group/meta.ts
+++ b/apps/web/src/registry/radio-group/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Radio Group",
   category: "form",
-  order: 160,
   description: "Single-selection group. Use value + onValueChange for controlled behaviour.",
 };

--- a/apps/web/src/registry/radio/meta.ts
+++ b/apps/web/src/registry/radio/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Radio",
   category: "form",
-  order: 150,
   description: "Single native radio input. Use Radio Group for accessible keyboard-navigable groups.",
 };

--- a/apps/web/src/registry/resizable/meta.ts
+++ b/apps/web/src/registry/resizable/meta.ts
@@ -3,7 +3,6 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Resizable",
   category: "layout",
-  order: 60,
   description: "Drag-to-resize panel groups. Supports horizontal, vertical, and nested layouts.",
   wide: true,
 };

--- a/apps/web/src/registry/scroll-area/meta.ts
+++ b/apps/web/src/registry/scroll-area/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Scroll Area",
   category: "layout",
-  order: 40,
   description: "Custom-styled scrollbar that matches your design system. Hides native OS scrollbars.",
 };

--- a/apps/web/src/registry/select/meta.ts
+++ b/apps/web/src/registry/select/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Select",
   category: "form",
-  order: 100,
   description: "Accessible dropdown selector. Supports groups, disabled options, and custom triggers.",
 };

--- a/apps/web/src/registry/separator/meta.ts
+++ b/apps/web/src/registry/separator/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Separator",
   category: "layout",
-  order: 30,
   description: "Semantic horizontal or vertical divider. Renders as hr with role=separator.",
 };

--- a/apps/web/src/registry/sheet/meta.ts
+++ b/apps/web/src/registry/sheet/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Sheet",
   category: "overlay",
-  order: 100,
   description: "Side-anchored panel (left, right, top, or bottom). Useful for settings and detail drawers.",
 };

--- a/apps/web/src/registry/sidebar/meta.ts
+++ b/apps/web/src/registry/sidebar/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Sidebar",
   category: "navigation",
-  order: 60,
   description: "Composable application sidebar with collapsible groups, rail, and mobile sheet. Built for app shells.",
 };

--- a/apps/web/src/registry/skeleton/meta.ts
+++ b/apps/web/src/registry/skeleton/meta.ts
@@ -3,7 +3,6 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Skeleton",
   category: "feedback",
-  order: 30,
   description: "Shimmer placeholder for any shape of content — cards, text lines, avatars.",
   wide: true,
 };

--- a/apps/web/src/registry/slider/meta.ts
+++ b/apps/web/src/registry/slider/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Slider",
   category: "form",
-  order: 190,
   description: "Range input with keyboard support. Supports min, max, step, and multiple thumbs.",
 };

--- a/apps/web/src/registry/sonner/meta.ts
+++ b/apps/web/src/registry/sonner/meta.ts
@@ -3,7 +3,6 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Sonner",
   category: "feedback",
-  order: 40,
   description: "Toast notifications via Sonner. Supports success, error, warning, and custom durations.",
   wide: true,
 };

--- a/apps/web/src/registry/spinner/meta.ts
+++ b/apps/web/src/registry/spinner/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Spinner",
   category: "display",
-  order: 40,
   description: "Indeterminate loading indicator. Wrap children — shown when loading is false.",
 };

--- a/apps/web/src/registry/switch/meta.ts
+++ b/apps/web/src/registry/switch/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Switch",
   category: "form",
-  order: 180,
   description: "Toggle control for boolean settings. Fires onCheckedChange with the new boolean value.",
 };

--- a/apps/web/src/registry/table/meta.ts
+++ b/apps/web/src/registry/table/meta.ts
@@ -3,7 +3,6 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Table",
   category: "display",
-  order: 110,
   description: "Semantic HTML table with styled header, body, footer, and caption slots.",
   wide: true,
 };

--- a/apps/web/src/registry/tabs/meta.ts
+++ b/apps/web/src/registry/tabs/meta.ts
@@ -3,7 +3,6 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Tabs",
   category: "navigation",
-  order: 10,
   description: "Accessible tabbed interface. Automatic or manual activation via activationMode.",
   wide: true,
 };

--- a/apps/web/src/registry/textarea/meta.ts
+++ b/apps/web/src/registry/textarea/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Textarea",
   category: "form",
-  order: 90,
   description: "Multiline text input. Pair with Label and field utilities for accessible forms.",
 };

--- a/apps/web/src/registry/toggle-group/meta.ts
+++ b/apps/web/src/registry/toggle-group/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Toggle Group",
   category: "form",
-  order: 210,
   description: "Single or multiple selection group of toggle buttons. Ideal for toolbars and alignment pickers.",
 };

--- a/apps/web/src/registry/toggle/meta.ts
+++ b/apps/web/src/registry/toggle/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Toggle",
   category: "form",
-  order: 200,
   description: "Pressable button with active/inactive state. Use ToggleGroup for exclusive selection.",
 };

--- a/apps/web/src/registry/tooltip/meta.ts
+++ b/apps/web/src/registry/tooltip/meta.ts
@@ -3,6 +3,5 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Tooltip",
   category: "overlay",
-  order: 20,
   description: "Hover label with delay and side placement control. Supports rich content including Kbd.",
 };

--- a/apps/web/src/registry/typography/meta.ts
+++ b/apps/web/src/registry/typography/meta.ts
@@ -3,7 +3,6 @@ import type { ComponentMetaInput } from "#/registry/components";
 export const meta: ComponentMetaInput = {
   name: "Typography",
   category: "display",
-  order: 130,
   description: "Styled headings, paragraphs, lists, blockquotes, and tables built from Tailwind utility classes.",
   wide: true,
   composition: [],


### PR DESCRIPTION
## What & why

The `/components` listing was refactored to group **A–Z** (`groups.ts`) instead of by category. That left a few things stranded that this PR cleans up:

- The curated **`order`** field (a per-category sort position) no longer drives anything — the registry and the detail-page pager now sort purely A–Z by name.
- The detail breadcrumb still had a middle segment linking to `#<category>`, an anchor that no longer exists on the A–Z listing → dead scroll target.
- The ⌘K palette navigated non-demo items to that same dead `#<category>` anchor.

`category` itself is **kept** — it's a genuinely useful descriptive tag, just no longer a sort key.

## Changes

- **Remove `order`** from `ComponentMetaInput` and all 65 `meta.ts` files; drop `CATEGORY_RANK` and the category-then-order comparator. `COMPONENTS` now sorts `a.name.localeCompare(b.name)`.
- **Keep `category`** as a descriptive tag — still powers the detail-page badge and the ⌘K palette label + search keyword (typing "form" surfaces inputs).
- **Breadcrumb**: drop the category segment → `Components › {Name}`.
- **⌘K palette**: non-demo items jump to their A–Z **letter band** (`#letter-X`) instead of the removed category anchor.
- **Tests**: assert A–Z ordering; drop the now-meaningless order-uniqueness test; keep the known-category check.

## Notes for reviewer

- Scope is entirely `apps/web` (not a publishable package), so no changeset.
- No component currently sets a `status`, so the detail badge row shows only the category badge today.

## Verification

- `pnpm run check-types` — 10/10 pass
- `pnpm run lint:fix` — clean
- Web registry tests — 15/15 pass (incl. new A–Z sort assertion)
- Rendered on dev server: breadcrumb `Components › Button`, detail badge `Form`, listing letter bands intact